### PR TITLE
Add support for new UUID/player name texture API.

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ image = MinecraftAvatars::Face.new(player_name, size = 64, accessories = true)
 # Extract the standard character avatar (front of the head, arms, legs, and torso) to a 32x64 image
 image = MinecraftAvatars::FlatCharacter.new(player_name, size = 64, accessories = true)
 ```
-Keep in mind that avatars are not lazy-loaded and perform an HTTP request every time the class is intialized.
+Keep in mind that avatars are not lazy-loaded and perform an HTTP request every time the class is intialized. Be warned that the texture API is heavily rate limited (currently once per second per player texture), if you require different sizes of avatars then call resize(size) on a Face or FlatCharacter object to save API calls.
 ```ruby
 # Get the raw blob (this is what youll likely be using)
 image.to_blob(constraints = {})

--- a/lib/minecraft-avatars.rb
+++ b/lib/minecraft-avatars.rb
@@ -3,7 +3,9 @@ require "minecraft-avatars/flat_character"
 require "minecraft-avatars/face"
 
 module MinecraftAvatars
-  SKIN_URL = "http://s3.amazonaws.com/MinecraftSkins"
+  RESOLVE_UUID_URL = "https://api.mojang.com/users/profiles/minecraft"
+  TEXTURE_URL = "https://sessionserver.mojang.com/session/minecraft/profile"
+
   SKIN_SECTIONS = {
     :head_front => [8, 8, 8, 8],
     :head_accessory => [40, 8, 8, 8],

--- a/lib/minecraft-avatars/face.rb
+++ b/lib/minecraft-avatars/face.rb
@@ -4,20 +4,25 @@ require 'minecraft-avatars/exceptions'
 
 module MinecraftAvatars
   class Face < BaseImage
+    attr_accessor :skin
 
     def initialize(player_name, size=64)
-
       throw InvalidResolutionException unless (size & (size-1)) == 0
 
-      skin = RawSkin.new(player_name)
-      self.chunky = ChunkyPNG::Image.new(8, 8, ChunkyPNG::Color::TRANSPARENT)
+      self.skin = RawSkin.new(player_name)
 
-      self.chunky.compose!(skin.sections[:head_front], 0, 0)
-      self.chunky.compose!(skin.sections[:head_accessory], 0, 0)
-
-      self.chunky.resample_nearest_neighbor!(size, size)
-
+      resize size
     end
 
+    def resize(size)
+      throw InvalidResolutionException unless (size & (size-1)) == 0
+
+      self.chunky = ChunkyPNG::Image.new(8, 8, ChunkyPNG::Color::TRANSPARENT)
+
+      self.chunky.compose!(self.skin.sections[:head_front], 0, 0)
+      self.chunky.compose!(self.skin.sections[:head_accessory], 0, 0)
+
+      self.chunky.resample_nearest_neighbor!(size, size)
+    end
   end
 end

--- a/lib/minecraft-avatars/face.rb
+++ b/lib/minecraft-avatars/face.rb
@@ -9,7 +9,11 @@ module MinecraftAvatars
     def initialize(player_name, size=64)
       throw InvalidResolutionException unless (size & (size-1)) == 0
 
-      self.skin = RawSkin.new(player_name)
+      if player_name.length == 36
+        self.skin = RawSkin.new(nil, player_name)
+      else
+        self.skin = RawSkin.new(player_name)
+      end
 
       resize size
     end

--- a/lib/minecraft-avatars/flat_character.rb
+++ b/lib/minecraft-avatars/flat_character.rb
@@ -10,7 +10,12 @@ module MinecraftAvatars
     def initialize(player_name, height=64, accessories=true)
       throw InvalidResolutionException unless (height & (height-1)) == 0
 
-      self.skin = RawSkin.new(player_name)
+      if player_name.length == 36
+        self.skin = RawSkin.new(nil, player_name)
+      else
+        self.skin = RawSkin.new(player_name)
+      end
+
       self.accessories = accessories
     end
 

--- a/lib/minecraft-avatars/flat_character.rb
+++ b/lib/minecraft-avatars/flat_character.rb
@@ -4,28 +4,32 @@ require 'minecraft-avatars/exceptions'
 
 module MinecraftAvatars
   class FlatCharacter < BaseImage
+    attr_accessor :skin
+    attr_accessor :accessories
 
     def initialize(player_name, height=64, accessories=true)
-
       throw InvalidResolutionException unless (height & (height-1)) == 0
-      
-      width = height/2
 
-      skin = RawSkin.new(player_name)
+      self.skin = RawSkin.new(player_name)
+      self.accessories = accessories
+    end
+
+    def resize(height)
+      throw InvalidResolutionException unless (height & (height-1)) == 0
+
+      width = height/2
 
       self.chunky = ChunkyPNG::Image.new(16, 32, ChunkyPNG::Color::TRANSPARENT)
 
-      self.chunky.compose!(skin.sections[:head_front], 4, 0)
-      self.chunky.compose!(skin.sections[:head_accessory], 4, 0) if accessories
-      self.chunky.compose!(skin.sections[:body_front], 4, 8)
-      self.chunky.compose!(skin.sections[:leg_front], 4, 20)
-      self.chunky.compose!(skin.sections[:leg_front].mirror, 8, 20)
-      self.chunky.compose!(skin.sections[:arm_front], 0, 8)
-      self.chunky.compose!(skin.sections[:arm_front].mirror, 12, 8)
+      self.chunky.compose!(self.skin.sections[:head_front], 4, 0)
+      self.chunky.compose!(self.skin.sections[:head_accessory], 4, 0) if self.accessories
+      self.chunky.compose!(self.skin.sections[:body_front], 4, 8)
+      self.chunky.compose!(self.skin.sections[:leg_front], 4, 20)
+      self.chunky.compose!(self.skin.sections[:leg_front].mirror, 8, 20)
+      self.chunky.compose!(self.skin.sections[:arm_front], 0, 8)
+      self.chunky.compose!(self.skin.sections[:arm_front].mirror, 12, 8)
 
       self.chunky.resample_nearest_neighbor!(width, height)
-
     end
-
   end
 end

--- a/lib/minecraft-avatars/raw_skin.rb
+++ b/lib/minecraft-avatars/raw_skin.rb
@@ -24,7 +24,7 @@ module MinecraftAvatars
       if uuid.nil?
         self.player_uuid = resolve_uuid player_name
       else
-        self.player_uuid = uuid
+        self.player_uuid = uuid.gsub("-", "")
       end
 
       self.texture_url, self.slim = resolve_texture self.player_uuid

--- a/lib/minecraft-avatars/raw_skin.rb
+++ b/lib/minecraft-avatars/raw_skin.rb
@@ -1,4 +1,6 @@
 require 'open-uri'
+require 'json'
+require 'base64'
 require 'chunky_png'
 require 'minecraft-avatars/exceptions'
 
@@ -7,28 +9,88 @@ module MinecraftAvatars
   class RawSkin
 
     attr_accessor :player_name
+    attr_accessor :player_uuid
+
     attr_accessor :sections
     attr_accessor :image
 
-    def initialize(player_name)
+    attr_accessor :texture_url
+    attr_accessor :slim
 
+    def initialize(player_name)
       self.sections = {}
       self.player_name = player_name
+
+      self.player_uuid = resolve_uuid player_name
+      
+      self.texture_url, self.slim = resolve_texture self.player_uuid
+      
+      download_texture
+
+      deconstruct
+    end
+
+    def resolve_uuid(player_name)
       begin
-        image_uri = open "#{MinecraftAvatars::SKIN_URL}/#{player_name}.png"
+        profile_uri = open "#{RESOLVE_UUID_URL}/#{player_name}"
+        profile = profile_uri.read
+        profile_json = JSON.parse profile
+        return profile_json["id"]
+      rescue JSON::ParserError => e
+        raise MinecraftAvatars::InvalidPlayerException.new(self.player_name)
+      rescue OpenURI::HTTPError => e
+        raise MinecraftAvatars::InvalidPlayerException.new(self.player_name)
+      end
+    end
+
+    def resolve_texture(uuid)
+      begin
+        texture_uri = open "#{TEXTURE_URL}/#{uuid}"
+        texture = texture_uri.read
+        texture_json = JSON.parse texture
+
+        properties = texture_json["properties"]
+
+        properties.each do |property|
+          if property["name"] == "textures"
+            decoded_texture_raw = Base64.decode64 property["value"]
+            texture_data = JSON.parse decoded_texture_raw
+
+            if texture_data.has_key?("textures") && texture_data["textures"].has_key?("SKIN") && texture_data["textures"]["SKIN"].has_key?("url")
+              url = texture_data["textures"]["SKIN"]["url"]
+
+              slim = false
+
+              if texture_data["textures"]["SKIN"].has_key?("metadata") && texture_data["textures"]["SKIN"]["metadata"].has_key?("model")
+                slim = texture_data["textures"]["SKIN"]["metadata"]["model"] == "slim"
+              end
+
+              return [ url, slim ]
+            end
+          end
+        end
+
+        raise MinecraftAvatars::InvalidPlayerException.new(self.player_name)
+      rescue JSON::ParserError => e
+        raise MinecraftAvatars::InvalidPlayerException.new(self.player_name)
+      rescue OpenURI::HTTPError => e
+        raise MinecraftAvatars::InvalidPlayerException.new(self.player_name)
+      end        
+    end
+
+    def download_texture
+      begin
+        image_uri = open self.texture_url
         raw_data = image_uri.read
       rescue OpenURI::HTTPError => e
         if e.message == "403 Forbidden"
-          raise MinecraftAvatars::InvalidPlayerException.new(player_name)
+          raise MinecraftAvatars::InvalidPlayerException.new(self.player_name)
         else
           raise e
         end
       end
 
       self.image = ChunkyPNG::Image.from_blob(raw_data)
-
-      deconstruct
-
     end
 
     def deconstruct

--- a/lib/minecraft-avatars/raw_skin.rb
+++ b/lib/minecraft-avatars/raw_skin.rb
@@ -17,7 +17,7 @@ module MinecraftAvatars
     attr_accessor :texture_url
     attr_accessor :slim
 
-    def initialize(player_name, uuid => nil)
+    def initialize(player_name, uuid = nil)
       self.sections = {}
       self.player_name = player_name
 

--- a/lib/minecraft-avatars/raw_skin.rb
+++ b/lib/minecraft-avatars/raw_skin.rb
@@ -17,12 +17,16 @@ module MinecraftAvatars
     attr_accessor :texture_url
     attr_accessor :slim
 
-    def initialize(player_name)
+    def initialize(player_name, uuid => nil)
       self.sections = {}
       self.player_name = player_name
 
-      self.player_uuid = resolve_uuid player_name
-      
+      if uuid.nil?
+        self.player_uuid = resolve_uuid player_name
+      else
+        self.player_uuid = uuid
+      end
+
       self.texture_url, self.slim = resolve_texture self.player_uuid
       
       download_texture

--- a/lib/minecraft-avatars/version.rb
+++ b/lib/minecraft-avatars/version.rb
@@ -1,3 +1,3 @@
 module MinecraftAvatars
-  VERSION = "0.0.5"
+  VERSION = "0.0.6"
 end

--- a/lib/minecraft-avatars/version.rb
+++ b/lib/minecraft-avatars/version.rb
@@ -1,3 +1,3 @@
 module MinecraftAvatars
-  VERSION = "0.0.4"
+  VERSION = "0.0.5"
 end

--- a/lib/minecraft-avatars/version.rb
+++ b/lib/minecraft-avatars/version.rb
@@ -1,3 +1,3 @@
 module MinecraftAvatars
-  VERSION = "0.0.2"
+  VERSION = "0.0.3"
 end

--- a/lib/minecraft-avatars/version.rb
+++ b/lib/minecraft-avatars/version.rb
@@ -1,3 +1,3 @@
 module MinecraftAvatars
-  VERSION = "0.0.3"
+  VERSION = "0.0.4"
 end


### PR DESCRIPTION
As above, this uses the Mojang UUID API for looking up a texture, rather then attempting to grab it from the legacy store. It doesn't yet take into account Slim textures like Alex.

Added support for a resize call for both Face and FlatCharacter to allow generation of multiple avatars at once without incurring the the API cost.
